### PR TITLE
Feature: Run Cairo function with arguments

### DIFF
--- a/cairo-hints/scarb-hints-run/main.rs
+++ b/cairo-hints/scarb-hints-run/main.rs
@@ -7,7 +7,8 @@ use std::{
 
 use anyhow::{Context, Result};
 use cairo_lang_sierra::program::VersionedProgram;
-use cairo_oracle_hint_processor::{run_1, Error};
+use cairo_oracle_hint_processor::{run_1, Error, FuncArg, FuncArgs};
+use cairo_vm::Felt252;
 use camino::Utf8PathBuf;
 use clap::Parser;
 use itertools::Itertools;
@@ -48,6 +49,44 @@ struct Args {
 
     #[arg(long)]
     memory_file: Option<PathBuf>,
+
+    #[arg(long = "args", default_value = "", value_parser=process_args)]
+    args: FuncArgs,
+}
+
+fn process_args(value: &str) -> Result<FuncArgs, String> {
+    if value.is_empty() {
+        return Ok(FuncArgs::default());
+    }
+    let mut args = Vec::new();
+    let mut input = value.split(' ');
+    while let Some(value) = input.next() {
+        // First argument in an array
+        if value.starts_with('[') {
+            let mut array_arg =
+                vec![Felt252::from_dec_str(value.strip_prefix('[').unwrap()).unwrap()];
+            // Process following args in array
+            let mut array_end = false;
+            while !array_end {
+                if let Some(value) = input.next() {
+                    // Last arg in array
+                    if value.ends_with(']') {
+                        array_arg
+                            .push(Felt252::from_dec_str(value.strip_suffix(']').unwrap()).unwrap());
+                        array_end = true;
+                    } else {
+                        array_arg.push(Felt252::from_dec_str(value).unwrap())
+                    }
+                }
+            }
+            // Finalize array
+            args.push(FuncArg::Array(array_arg))
+        } else {
+            // Single argument
+            args.push(FuncArg::Single(Felt252::from_dec_str(value).unwrap()))
+        }
+    }
+    Ok(FuncArgs(args))
 }
 
 fn validate_layout(value: &str) -> Result<String, String> {
@@ -109,6 +148,7 @@ fn main() -> Result<(), Error> {
         &args.layout,
         &args.trace_file,
         &args.memory_file,
+        &args.args,
         &sierra_program,
         "::main",
         args.proof_mode,

--- a/cairo-hints/scarb-hints-run/main.rs
+++ b/cairo-hints/scarb-hints-run/main.rs
@@ -50,6 +50,7 @@ struct Args {
     #[arg(long)]
     memory_file: Option<PathBuf>,
 
+    /// Arguments of the Cairo function.
     #[arg(long = "args", default_value = "", value_parser=process_args)]
     args: FuncArgs,
 }

--- a/cairo-lang-hints-test-runner/src/lib.rs
+++ b/cairo-lang-hints-test-runner/src/lib.rs
@@ -14,7 +14,7 @@ use cairo_lang_test_plugin::test_config::{PanicExpectation, TestExpectation};
 use cairo_lang_test_plugin::{
     compile_test_prepared_db, test_plugin_suite, TestCompilation, TestConfig,
 };
-use cairo_oracle_hint_processor::{run_1, Error};
+use cairo_oracle_hint_processor::{run_1, Error, FuncArgs};
 use cairo_proto_serde::configuration::Configuration;
 use cairo_vm::Felt252 as VMFelt;
 use colored::Colorize;
@@ -318,6 +318,7 @@ pub fn run_tests(
                     layout,
                     &None,
                     &None,
+                    &FuncArgs::default(),
                     &sierra_program,
                     &name,
                     false,

--- a/cairo-oracle-hint-processor/src/lib.rs
+++ b/cairo-oracle-hint-processor/src/lib.rs
@@ -78,13 +78,13 @@ pub enum Error {
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
-enum FuncArg {
+pub enum FuncArg {
     Array(Vec<Felt252>),
     Single(Felt252),
 }
 
 #[derive(Debug, Clone, Default)]
-struct FuncArgs(Vec<FuncArg>);
+pub struct FuncArgs(pub Vec<FuncArg>);
 
 pub struct FileWriter {
     buf_writer: io::BufWriter<std::fs::File>,
@@ -125,6 +125,7 @@ pub fn run_1(
     layout: &str,
     trace_file: &Option<PathBuf>,
     memory_file: &Option<PathBuf>,
+    args: &FuncArgs,
     sierra_program: &SierraProgram,
     entry_func_name: &str,
     proof_mode: bool,
@@ -143,7 +144,7 @@ pub fn run_1(
         relocate_mem: memory_file.is_some(), //|| air_public_input.is_some(),
         layout: layout,
         trace_enabled: trace_file.is_some(), //|| args.air_public_input.is_some(),
-        args: &[],
+        args: &args.0,
         finalize_builtins: false, //args.air_private_input.is_some() || args.cairo_pie_output.is_some(),
     };
 

--- a/documentation/Reference.md
+++ b/documentation/Reference.md
@@ -71,6 +71,7 @@ Options:
       --oracle-lock <ORACLE_LOCK>
       --trace-file <TRACE_FILE>
       --memory-file <MEMORY_FILE>
+      --args <ARGS>                    [default: ]
   -h, --help                           Print help
   -V, --version                        Print version
 ```
@@ -105,6 +106,8 @@ Other choices are:
 `--trace-file` is the filepath of the trace file generated when executing `scarb hints-run`. If flag is missing, no trace file is generated. Needed if using `--proof-mode`.
 
 `--memory-file` is the filepath of the memory file generated when executing `scarb hints-run`. If flag is missing, no memory file is generated. Needed if using `--proof-mode`.
+
+`--args` flag needed if the Cairo function has arguments. Arguments should be spaced, with array elements placed between brackets. For example " --args '1 2 [1 2 3]'" will yield 3 arguments, with the last one being an array of 3 elements
 
 ## `scarb hints-test`
 


### PR DESCRIPTION
This PR adds `--args` flag to `scarb-hints-run`  as discussed in #22, in order to run Cairo functions with arguments as follow:
`scarb hints-run --oracle-server http://127.0.0.1:3000 --layout all_cairo --args "1764"`

Arguments should be spaced, with array elements placed between brackets For example " --args '1 2 [1 2 3]'" will yield 3 arguments, with the last one being an array of 3 elements.